### PR TITLE
python3 requires parenthesis on `print` statements

### DIFF
--- a/pony_lldb.py
+++ b/pony_lldb.py
@@ -106,7 +106,7 @@ def _char_or_dot(c):
 
 
 def _register_summary(debugger, function_name, type_name):
-    print "registering '%s'" % (type_name,)
+    print("registering '%s'" % (type_name,))
     summary = lldb.SBTypeSummary.CreateWithFunctionName(function_name)
     summary.SetOptions(lldb.eTypeOptionHideChildren)
     debugger.GetDefaultCategory().AddTypeSummary(


### PR DESCRIPTION
recent versions of `lldb` use `python3` which is more strict about having parens on `print` statements.

The existing version throws this error when running `command script import $PATH_TO_PONY_LLDB/pony-lldb/pony_lldb.py`:

```
error: module importing failed: Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/tednaleid/Documents/workspace/pony/pony-lldb/pony_lldb.py", line 109
    print "registering '%s'" % (type_name,)
          ^
```

adding the parens gets it working again:

![working lldb session in VSCode](https://user-images.githubusercontent.com/5231/129422958-1c8cb1d2-92ce-4b7f-aba3-7f78aa17bc71.png)
