### PR TITLE
Upgrade pylint from 2.9.3 to 3.3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN apt-get update \
   && apt-get -y clean
 
 RUN pip3 install --break-system-packages \
-  pylint==2.9.3
+  pylint==3.3.9
 
 COPY pony_lldb.py /pony_lldb.py


### PR DESCRIPTION
pylint 2.9.3 depends on wrapt 1.12.1, which uses `inspect.formatargspec` — removed in Python 3.12. The Dockerfile uses Ubuntu 24.04 (Python 3.12), so pylint crashes on import, causing the "Lint pony_lldb.py" CI check to fail on every PR.

Upgrades to pylint 3.3.9, which supports Python 3.12.